### PR TITLE
Add binary stanza for SourceGit

### DIFF
--- a/.github/workflows/update_tap_upon_new_version.yml
+++ b/.github/workflows/update_tap_upon_new_version.yml
@@ -516,6 +516,7 @@ jobs:
             depends_on macos: ">= :big_sur"
 
             app "SourceGit.app"
+            binary "#{appdir}/SourceGit.app/Contents/MacOS/SourceGit", target: "sourcegit"
 
             zap trash: [
               "~/Library/Application Support/SourceGit",

--- a/Casks/sourcegit.rb
+++ b/Casks/sourcegit.rb
@@ -18,6 +18,7 @@ cask "sourcegit" do
   depends_on macos: ">= :big_sur"
 
   app "SourceGit.app"
+  binary "#{appdir}/SourceGit.app/Contents/MacOS/SourceGit", target: "sourcegit"
 
   zap trash: [
     "~/Library/Application Support/SourceGit",


### PR DESCRIPTION
It's handy to open SourceGit from the command line, see https://github.com/sourcegit-scm/sourcegit?tab=readme-ov-file#commandline-arguments.

This change will add a symlink from `/opt/homebrew/bin/sourcegit` to `/Applications/SourceGit.app/Contents/MacOS/SourceGit`. Or should we name it `sgit` analogous to `stree` [used by SourceTree](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/s/sourcetree.rb)?